### PR TITLE
Add slack EOD Reminder Bot workflow

### DIFF
--- a/.github/workflows/slack-eod-bot.yaml
+++ b/.github/workflows/slack-eod-bot.yaml
@@ -1,0 +1,15 @@
+name: Slack EOD Reminder Bot
+
+on:
+  schedule:
+    - cron: "30 13 * * *" # 7:00pm IST
+  workflow_dispatch:
+
+jobs:
+  run-slack-eod-reminder:
+    uses: coronasafe/leaderboard/.github/workflows/slack_eod_reminder.yaml@slack-eod-bot
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      issues: read
+      pull-requests: read
+    secrets: inherit


### PR DESCRIPTION
- Dependent on: https://github.com/coronasafe/leaderboard/pull/
- Runs every 19:00 IST

<img width="641" alt="image" src="https://github.com/coronasafe/leaderboard-data/assets/25143503/1a4f99d6-4dbe-4502-8555-3c4de0c95998">

<img width="792" alt="image" src="https://github.com/coronasafe/leaderboard-data/assets/25143503/2d386f3a-d6cf-4685-968d-4e686e0417ee">


